### PR TITLE
Make project files visible in qtcreator

### DIFF
--- a/{{cookiecutter.app_name}}/CMakeLists.txt
+++ b/{{cookiecutter.app_name}}/CMakeLists.txt
@@ -60,3 +60,16 @@ add_custom_target(${DESKTOP_FILE_NAME} ALL
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${DESKTOP_FILE_NAME} DESTINATION ${DATA_DIR})
 
 add_subdirectory(po)
+
+# Make source files visible in qtcreator
+file(GLOB_RECURSE PROJECT_SRC_FILES
+    RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
+    qml/*.qml
+    qml/*.js
+    *.json
+    *.json.in
+    *.apparmor
+    *.desktop.in
+)
+
+add_custom_target(${PROJECT_NAME}_FILES ALL SOURCES ${PROJECT_SRC_FILES})


### PR DESCRIPTION
Currently the template makes only the i18n files visible in QtCreator, so this addition makes all relevant project source files visible.

I will also create PR's for the other cmake based templates as some folks will still want to use qtcreator and opening qtcreator to what seems like an empty project is confusing.